### PR TITLE
Fix rootURL assignment in main.js

### DIFF
--- a/main.js
+++ b/main.js
@@ -94,7 +94,10 @@ async function main() {
     await ensureConformed()
     const model = inferenceModelsList[this.selectedIndex]
     const opts = brainChopOpts
-    opts.rootURL = location.href
+    // opts.rootURL should be the url without the query string
+    const urlParams = new URL(window.location.href)
+    // remove the query string
+    opts.rootURL = urlParams.origin + urlParams.pathname
     const isLocalhost = Boolean(
       window.location.hostname === 'localhost' ||
         // [::1] is the IPv6 localhost address.

--- a/tests/model11.spec.cjs
+++ b/tests/model11.spec.cjs
@@ -11,6 +11,8 @@ async function waitForLogMessage(page, browserName, modelIndex) {
   const logMessagePromise = new Promise((resolve, reject) => {
     page.on('console', (msg) => {
       const msgText = msg.text();
+      // log all messages to help debug github actions
+      console.log(msgText);
       if (msgText.includes('Processing the whole brain volume in tfjs for multi-class output mask took :')) {
         // Parse the time in milliseconds
         const time = parseFloat(msgText.split('took : ')[1].split(' Seconds')[0]) * 1000;


### PR DESCRIPTION
This PR fixes a bug that was introduced in my previous PR #42. 

In PR #42, I added the ability to use query parameters to immediately run a model by setting the `model` query string. As an example, the URL `https://brainchop.org/?model=11` would immediately set the model to the model at the 11th index in the list and then run it. This behaviour is useful for testing in an automated way. This method didn't work when deployed to github pages. 

This should be fixed now. 

