### PR TITLE
Control WEBGL_DELETE_TEXTURE_THRESHOLD

### DIFF
--- a/brainchop-parameters.js
+++ b/brainchop-parameters.js
@@ -17,7 +17,8 @@ const brainChopOpts = {
   telemetryFlag: false, // Ethical and transparent collection of browser usage while adhering to security and privacy standards
   chartXaxisStepPercent: 10, // percent from total labels on Xaxis
   uiSampleName: 'BC_UI_Sample', // Sample name used by interface
-  atlasSelectedColorTable: 'Fire' // Select from ["Hot-and-Cold", "Fire", "Grayscale", "Gold", "Spectrum"]
+  atlasSelectedColorTable: 'Fire', // Select from ["Hot-and-Cold", "Fire", "Grayscale", "Gold", "Spectrum"]
+  deleteTextureThreshold: -1 //0 for reduced memory (delete textures when tensors disposed), -1 for faster and support Intel GPU+Windows
 }
 
 // Inference Models, the ids must start from 1 in sequence

--- a/brainchop-webworker.js
+++ b/brainchop-webworker.js
@@ -207,7 +207,7 @@ async function inferenceFullVolumeSeqCovLayerPhase2(
     while (true) {
       try {
         if (res.layers[i].activation.getClassName() !== 'linear') {
-          curTensor[i] = await res.layers[i].apply(curTensor[i - 1])
+          curTensor[i] = await res.layers[i].apply(curTensor[i - 1], opts.deleteTextureThreshold)
         } else {
           curTensor[i] = await convByOutputChannelAndInputSlicing(
             curTensor[i - 1],
@@ -264,7 +264,7 @@ async function inferenceFullVolumeSeqCovLayerPhase2(
         let outputTensor = null
         const profileInfo = await tf.profile(async () => {
           // Your tensor operations here
-          outputTensor = await seqConvLayer.apply(curTensor[i])
+          outputTensor = await seqConvLayer.apply(curTensor[i], opts.deleteTextureThreshold)
         })
         console.log('profileInfo : ', profileInfo)
 
@@ -576,7 +576,7 @@ async function inferenceFullVolumePhase2(
     while (true) {
       try {
         // -- curTensor[i] = res.layers[i].apply( curTensor[i-1])
-        curTensor[i] = res.layers[i].apply(curTensor[i - 1])
+        curTensor[i] = res.layers[i].apply(curTensor[i - 1], opts.deleteTextureThreshold)
       } catch (err) {
         callbackUI(err.message, -1, err.message)
         tf.engine().endScope()
@@ -918,7 +918,7 @@ async function inferenceFullVolumePhase1(
       tf.dispose(preModel_slices_3d)
       while (true) {
         try {
-          curTensor[i] = res.layers[i].apply(curTensor[i - 1])
+          curTensor[i] = res.layers[i].apply(curTensor[i - 1], opts.deleteTextureThreshold)
         } catch (err) {
           const errTxt = 'Your graphics card (e.g. Intel) may not be compatible with WebGL. ' + err.message
           callbackUI(errTxt, -1, errTxt)
@@ -1212,7 +1212,7 @@ async function inferenceFullVolumePhase1(
   }
 }
 
-async function enableProductionMode(textureF16Flag = true) {
+async function enableProductionMode(textureF16Flag = true, deleteTextureThreshold = 0) {
   // -- tf.setBackend('cpu')
   tf.setBackend('webgl')
   // -- tf.removeBackend('cpu')
@@ -1222,7 +1222,7 @@ async function enableProductionMode(textureF16Flag = true) {
   tf.env().set('DEBUG', false)
   tf.env().set('WEBGL_FORCE_F16_TEXTURES', textureF16Flag)
   // -- set this flag so that textures are deleted when tensors are disposed.
-  tf.env().set('WEBGL_DELETE_TEXTURE_THRESHOLD', 0)
+  tf.env().set('WEBGL_DELETE_TEXTURE_THRESHOLD', deleteTextureThreshold)
   // -- tf.env().set('WEBGL_PACK', false)
   // -- Put ready after sets above
   await tf.ready()
@@ -1253,7 +1253,7 @@ async function runInferenceWW(opts, modelEntry, niftiHeader, niftiImage) {
   console.log('Batch size: ', batchSize)
   console.log('Num of Channels: ', numOfChan)
   const model = await load_model(opts.rootURL + modelEntry.path)
-  await enableProductionMode(true)
+  await enableProductionMode(true, opts.deleteTextureThreshold)
   statData.TF_Backend = tf.getBackend()
   const modelObject = model
   let batchInputShape = []

--- a/index.html
+++ b/index.html
@@ -29,6 +29,9 @@
     <label for="workerCheck">Use Webworker</label>
     <input type="checkbox" title="webworkers are faster but not supported by all browsers" id="workerCheck" checked />
     &nbsp;
+    <label for="deleteTextureCheck">Compatibility (slow)</label>
+    <input type="checkbox" title="deleting texture is slower but might improve compatibility" id="deleteTextureCheck" unchecked />
+    &nbsp;
     <label for="penDrop">Draw</label>
     <select id="penDrop">
       <option value="-1">Off</option>

--- a/main.js
+++ b/main.js
@@ -94,6 +94,8 @@ async function main() {
     await ensureConformed()
     const model = inferenceModelsList[this.selectedIndex]
     const opts = brainChopOpts
+    //deleteTextureThreshold 0 for forced texture deletion, -1 for faster and support Intel GPU+Windows
+    opts.deleteTextureThreshold = deleteTextureCheck.checked ? 0 : -1
     // opts.rootURL should be the url without the query string
     const urlParams = new URL(window.location.href)
     // remove the query string
@@ -143,6 +145,9 @@ async function main() {
     nv1.saveDocument("brainchop.nvd");
   }
   workerCheck.onchange = function () {
+    modelSelect.onchange()
+  }
+  deleteTextureCheck.onchange = function () {
     modelSelect.onchange()
   }
   clipCheck.onchange = function () {

--- a/tensor-utils.js
+++ b/tensor-utils.js
@@ -499,9 +499,9 @@ export class SequentialConvLayer {
    * @return {outC}
    */
 
-  async apply(inputTensor) {
+  async apply(inputTensor, deleteTextureThreshold = 0) {
     const oldDeleteTextureThreshold = tf.ENV.get('WEBGL_DELETE_TEXTURE_THRESHOLD')
-    tf.ENV.set('WEBGL_DELETE_TEXTURE_THRESHOLD', 0)
+    tf.ENV.set('WEBGL_DELETE_TEXTURE_THRESHOLD', deleteTextureThreshold)
 
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     const self = this


### PR DESCRIPTION
This pull request implements a partial fix for [an incompatibility with Intel GPUs running on the Windows operating system](https://github.com/tensorflow/tfjs/issues/8274). With this PR, more models run on that configuration. In addition, models in general run faster regardless of computer.

Previously, [brainchop used aggressive texture memory deallocation](https://github.com/neuroneural/brainchop/blob/098688a90efad3fa3e599f1ece360cd1fe3225f9/tensor-utils.js#L504):
```
tf.ENV.set('WEBGL_DELETE_TEXTURE_THRESHOLD', 0)
```

Now, this is only done if the user checks the `Compatibility (slow)` option. So the parameter is set to -1 by default (normal memory deallocation) and `0` if the user chooses the slow option. On my hardware, the normal (-1) was always faster and aided compatibility on Intel with Windows, while aggressive (0) was always slower (as expected) and did not actually improve compatibility. I decided to add a check box because my testing hardware is not exhaustive, perhaps there are cases where using the aggressive mode does help model execution.

![delete_textures](https://github.com/neuroneural/brainchop/assets/8930807/b1f3b84d-0f64-4c94-9a2b-ea3aa11d3457)

Long story short: this PR changes the default behavior for faster performance and more compatible behavior on the specific combination of an Intel GPU on the Windows operating system.


