### PR TITLE
More strict conformed requirement

### DIFF
--- a/main.js
+++ b/main.js
@@ -80,7 +80,8 @@ async function main() {
   async function ensureConformed() {
     const nii = nv1.volumes[0];
     let isConformed =
-      nii.dims[1] === 256 && nii.dims[2] === 256 && nii.dims[3] === 256;
+      nii.dims[1] === 256 && nii.dims[2] === 256 && nii.dims[3] === 256
+        && nii.img instanceof Uint8Array && nii.img.length === 256 * 256 * 256;
     if (
       nii.permRAS[0] !== -1 ||
       nii.permRAS[1] !== 3 ||


### PR DESCRIPTION
The current code requires that input data is not only conformed in shape, but coformed in datatype to uint8. Therefore, without this patch brainchop has issues with images that have the correct shape but wrong datatype.