### PR TITLE
Increase margin of cropping in case of mindgrab

### DIFF
--- a/brainchop-parameters.js
+++ b/brainchop-parameters.js
@@ -388,7 +388,7 @@ const inferenceModelsList = [
     numOverlapBatches: 0, // Number of extra overlap batches for inference
     enableTranspose: true, // Keras and tfjs input orientation may need a tranposing step to be matched
     enableCrop: true, // For speed-up inference, crop brain from background before feeding to inference model to lower memory use.
-    cropPadding: 0, // Padding size add to cropped brain
+    cropPadding: 10, // Padding size add to cropped brain
     autoThreshold: 0, // Threshold between 0 and 1, given no preModel and tensor is normalized either min-max or by quantiles. Will remove noisy voxels around brain
     enableQuantileNorm: false, // Some models needs Quantile Normaliztion.
     filterOutWithPreMask: false, // Can be used to multiply final output with premodel output mask to crean noisy areas
@@ -411,7 +411,7 @@ const inferenceModelsList = [
     numOverlapBatches: 0, // Number of extra overlap batches for inference
     enableTranspose: true, // Keras and tfjs input orientation may need a tranposing step to be matched
     enableCrop: true, // For speed-up inference, crop brain from background before feeding to inference model to lower memory use.
-    cropPadding: 0, // Padding size add to cropped brain
+    cropPadding: 10, // Padding size add to cropped brain
     autoThreshold: 0, // Threshold between 0 and 1, given no preModel and tensor is normalized either min-max or by quantiles. Will remove noisy voxels around brain
     enableQuantileNorm: false, // Some models needs Quantile Normaliztion.
     filterOutWithPreMask: false, // Can be used to multiply final output with premodel output mask to crean noisy areas


### PR DESCRIPTION
Turns out the default automatic cropping is too agressive for mindgrab, which makes it bleed into the skull. Adding a 10 voxel margin around that cropped volume seems to improve results. Definitely improves on the demo volume.