### PR TITLE
Loading model from url query paramters

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ To see Brainchop **v4** in action please click  [here](https://neuroneural.githu
 
 For **v3** click [here](https://neuroneural.github.io/brainchop/v3).
 
+You can link directly to a specific model using the `?model=` URL parameter, e.g. [neuroneural.github.io/brainchop?model=skull-strip](https://neuroneural.github.io/brainchop?model=skull-strip).
+
 <br>
 
 

--- a/brainchop-parameters.js
+++ b/brainchop-parameters.js
@@ -24,6 +24,7 @@ const brainChopOpts = {
 const inferenceModelsList = [
   {
     id: 1,
+    shortname: 'tissue-gwm',
     type: 'Segmentation',
     path: '/models/model5_gw_ae/model.json',
     modelName: '\u26A1 Tissue GWM (light)',
@@ -48,6 +49,7 @@ const inferenceModelsList = [
   },
   {
     id: 2,
+    shortname: 'skull-strip',
     type: 'Brain_Extraction',
     path: '/models/mindgrab/model.json',
     modelName: '\u{1FA93}\u{1F9E0} omnimodal Skull Stripping',
@@ -74,6 +76,7 @@ const inferenceModelsList = [
   },
   {
     id: 3,
+    shortname: 'subcortical-gwm',
     type: 'Atlas',
     path: '/models/model30chan18cls/model.json',
     modelName: '\u{1FA93} Subcortical + GWM',
@@ -99,6 +102,7 @@ const inferenceModelsList = [
   },
   {
     id: 4,
+    shortname: 'aparc50',
     type: 'Atlas',
     path: '/models/model30chan50cls/model.json',
     modelName: '\u{1F52A} Aparc+Aseg 50',
@@ -124,6 +128,7 @@ const inferenceModelsList = [
   },
   {
     id: 5,
+    shortname: 'aparc104',
     type: 'Atlas',
     path: '/models/model21_104class/model.json',
     modelName: '\u{1F52A} Aparc+Aseg 104',
@@ -155,6 +160,7 @@ const inferenceModelsList = [
   },
   {
     id: 7,
+    shortname: 'tissue-gwm-highacc',
     type: 'Segmentation',
     path: '/models/model20chan3cls/model.json',
     modelName: '\u{1F52A} Tissue GWM (High Acc)',
@@ -179,6 +185,7 @@ const inferenceModelsList = [
   },
   {
     id: 8,
+    shortname: 'subcortical-gwm-small',
     type: 'Atlas',
     path: '/models/model18cls/model.json',
     modelName: '\u{1FA93} Subcortical + GWM (Small Model)',
@@ -204,6 +211,7 @@ const inferenceModelsList = [
   },
   {
     id: 9,
+    shortname: 'brain-extract-fast',
     type: 'Brain_Extraction',
     path: '/models/model5_gw_ae/model.json',
     modelName: '\u26A1 Extract the Brain (FAST)',
@@ -226,6 +234,7 @@ const inferenceModelsList = [
   },
   {
     id: 10,
+    shortname: 'brain-extract-highacc',
     type: 'Brain_Extraction',
     path: '/models/model11_gw_ae/model.json',
     modelName: '\u{1F52A} Extract the Brain (High Acc, Slow)',
@@ -249,6 +258,7 @@ const inferenceModelsList = [
   },
   {
     id: 11,
+    shortname: 'brain-mask-fast',
     type: 'Brain_Masking',
     path: '/models/model5_gw_ae/model.json',
     modelName: '\u26A1 Brain Mask (FAST)',
@@ -272,6 +282,7 @@ const inferenceModelsList = [
   },
   {
     id: 12,
+    shortname: 'brain-mask-highacc',
     type: 'Brain_Masking',
     path: '/models/model11_gw_ae/model.json',
     modelName: '\u{1F52A} Brain Mask (High Acc, Low Mem)',

--- a/main.js
+++ b/main.js
@@ -641,8 +641,15 @@ async function main() {
   // Use URLSearchParams to correctly parse the query string.
   const urlParams = new URLSearchParams(window.location.search);
   const modelParam = urlParams.get("model");
-  if (modelParam && modelParam < inferenceModelsList.length) {
-    modelSelect.value = modelParam;
+  const modelIdxParam = urlParams.get("model_idx");
+  if (modelParam) {
+    const idx = inferenceModelsList.findIndex(m => m.shortname === modelParam);
+    if (idx >= 0) {
+      modelSelect.value = idx;
+      runSelectedInference();
+    }
+  } else if (modelIdxParam && modelIdxParam < inferenceModelsList.length) {
+    modelSelect.value = modelIdxParam;
     runSelectedInference();
   }
 }

--- a/main.js
+++ b/main.js
@@ -642,15 +642,16 @@ async function main() {
   const urlParams = new URLSearchParams(window.location.search);
   const modelParam = urlParams.get("model");
   const modelIdxParam = urlParams.get("model_idx");
+  let urlModelIdx = -1;
   if (modelParam) {
-    const idx = inferenceModelsList.findIndex(m => m.shortname === modelParam);
-    if (idx >= 0) {
-      modelSelect.value = idx;
-      runSelectedInference();
-    }
+    urlModelIdx = inferenceModelsList.findIndex(m => m.shortname === modelParam);
   } else if (modelIdxParam && modelIdxParam < inferenceModelsList.length) {
-    modelSelect.value = modelIdxParam;
-    runSelectedInference();
+    urlModelIdx = parseInt(modelIdxParam);
+  }
+  if (urlModelIdx >= 0) {
+    modelSelect.value = urlModelIdx;
+    await runSelectedInference();
+    modelSelect.value = urlModelIdx;
   }
 }
 


### PR DESCRIPTION
this PR adds support to load a model from adding a normalized model name after the url.

```
https://brainchop.org?model=skull-strip
```

will load omnimodal skull strip (aka mindgrab.